### PR TITLE
fix PKG_NAME & update packages

### DIFF
--- a/jpcre2/Makefile
+++ b/jpcre2/Makefile
@@ -22,14 +22,14 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/jpcre2
+define Package/$(PKG_NAME)
   SECTION:=lib
   CATEGORY:=Libraries
   TITLE:=C++ wrapper for PCRE2 Library
   URL:=https://github.com/jpcre2/jpcre2
 endef
 
-define Package/jpcre2/description
+define Package/$(PKG_NAME)/description
   This provides some C++ wrapper classes/functions to perform regex
   operations such as regex match and regex replace.
 endef
@@ -39,4 +39,4 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/jpcre2.hpp $(1)/usr/include/jpcre2.hpp
 endef
 
-$(eval $(call BuildPackage,jpcre2))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/libcron/Makefile
+++ b/libcron/Makefile
@@ -5,14 +5,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcron
-PKG_VERSION:=1.3.0
+PKG_VERSION:=1.4.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/PerMalmberg/libcron.git
-PKG_SOURCE_DATE:=2020-12-04
-PKG_SOURCE_VERSION:=b0046755bda166dde253e33f68a5b0a1c3ed387e
-PKG_MIRROR_HASH:=04ed111a5b15b713fc51ca728f5c2cbe386a5bff642a3b3e1b928b695f6cec2f
+PKG_SOURCE_DATE:=2021-08-24
+PKG_SOURCE_VERSION:=e91a51afc1d3e0ef2de8849e6c7bd84dd45d0ad9
+PKG_MIRROR_HASH:=e4e3f945aebdbee7ff4457399cd21241922c7de658733e94b85ca98a0f5b5a94
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -24,14 +24,14 @@ CMAKE_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-define Package/libcron
+define Package/$(PKG_NAME)
   SECTION:=lib
   CATEGORY:=Libraries
   URL:=https://github.com/PerMalmberg/libcron
   TITLE:=A C++ scheduling library using cron formatting
 endef
 
-define Package/libcron/description
+define Package/$(PKG_NAME)/description
   Libcron offers an easy to use API to add callbacks with corresponding cron-formatted strings.
 endef
 
@@ -43,4 +43,4 @@ define Build/Install
 	$(CP) $(PKG_BUILD_DIR)/libcron/externals/date/include/* $(PKG_INSTALL_DIR)/usr/include/
 endef
 
-$(eval $(call BuildPackage,libcron))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/libyaml-cpp/Makefile
+++ b/libyaml-cpp/Makefile
@@ -26,7 +26,7 @@ CMAKE_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-define Package/libyaml-cpp
+define Package/$(PKG_NAME)
   SECTION:=development
   CATEGORY:=Libraries
   TITLE:=libyaml-cpp
@@ -35,7 +35,7 @@ define Package/libyaml-cpp
   ABI_VERSION:=0.7
 endef
 
-define Package/libyaml-cpp/description
+define Package/$(PKG_NAME)/description
   yaml-cpp is a YAML parser and emitter in C++ matching the YAML 1.2 spec.
 endef
 
@@ -44,9 +44,9 @@ CMAKE_OPTIONS += \
 	-DYAML_CPP_BUILD_TESTS=OFF \
 	-DYAML_CPP_BUILD_TOOLS=OFF
 
-define Package/libyaml-cpp/install
+define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libyaml-cpp.so.$(ABI_VERSION) $(1)/usr/lib/
 endef
 
-$(eval $(call BuildPackage,libyaml-cpp))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/quickjspp/Makefile
+++ b/quickjspp/Makefile
@@ -9,9 +9,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/ftk/quickjspp.git
-PKG_SOURCE_DATE:=2021-04-13
-PKG_SOURCE_VERSION:=25037f37a02277ed8a8a0f4d61bac174254bf7b6
-PKG_MIRROR_HASH:=6a914acdaf31c2ed0adef3f36646105df4333355dd7c254d9590b0c11fee469e
+PKG_SOURCE_DATE:=2021-12-05
+PKG_SOURCE_VERSION:=b23a60a96219eb3fdba281b8a73ac6fa22df1704
+PKG_MIRROR_HASH:=9d152fd401f3eca406597cc40b63758bf32bb7c42a4f4e0385725426d6b43710
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 
@@ -21,7 +21,7 @@ CMAKE_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-define Package/quickjspp
+define Package/$(PKG_NAME)
   SECTION:=lib
   CATEGORY:=Libraries
   URL:=https://github.com/ftk/quickjspp
@@ -30,7 +30,7 @@ define Package/quickjspp
   PROVIDES:=quickjs
 endef
 
-define Package/quickjspp/description
+define Package/$(PKG_NAME)/description
   QuickJSPP is QuickJS wrapper for C++. It allows you to easily embed
   Javascript engine into your program.
 endef
@@ -43,4 +43,4 @@ define Build/Install
 	$(CP) $(PKG_BUILD_DIR)/quickjs/quickjs*.h $(PKG_INSTALL_DIR)/usr/include/quickjs/
 endef
 
-$(eval $(call BuildPackage,quickjspp))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/quickjspp/patches/0001-fix-std-namespace.patch
+++ b/quickjspp/patches/0001-fix-std-namespace.patch
@@ -1,0 +1,25 @@
+From bf320ea436f8fff5eefc998fec6ac7c63e30cc69 Mon Sep 17 00:00:00 2001
+From: W_Y_CPP <383152993@qq.com>
+Date: Sun, 26 Dec 2021 17:25:24 +0900
+Subject: [PATCH] fix std namespace
+
+---
+ test/conversions.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/conversions.cpp b/test/conversions.cpp
+index 0b2c782..7e014cc 100644
+--- a/test/conversions.cpp
++++ b/test/conversions.cpp
+@@ -2,7 +2,7 @@
+ #include <iostream>
+ #include <numeric>
+ #include <limits>
+-
++#include <stdexcept>
+ template <typename T>
+ void test_conv(qjs::Context& context, T x)
+ {
+-- 
+2.17.1
+

--- a/rapidjson/Makefile
+++ b/rapidjson/Makefile
@@ -9,9 +9,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Tencent/rapidjson.git
-PKG_SOURCE_DATE:=2021-08-13
-PKG_SOURCE_VERSION:=00dbcf2c6e03c47d6c399338b6de060c71356464
-PKG_MIRROR_HASH:=9c600748a8e6151341dd92be628f0a21263763e588b6d1c87dc834679da0714a
+PKG_SOURCE_DATE:=2021-11-24
+PKG_SOURCE_VERSION:=fd3dc29a5c2852df569e1ea81dbde2c412ac5051
+PKG_MIRROR_HASH:=4c9dbcfb7746202f7c9b7b4df78bd5349e7df21ee0f1fe816195eb013b4e194f
 
 PKG_LICENSE:=BSD 3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -27,15 +27,15 @@ CMAKE_OPTIONS+= -DRAPIDJSON_BUILD_DOC=OFF \
 	-DRAPIDJSON_BUILD_EXAMPLES=OFF \
 	-DRAPIDJSON_BUILD_TESTS=OFF
 
-define Package/rapidjson
+define Package/$(PKG_NAME)
   SECTION:=lib
   CATEGORY:=Libraries
   URL:=https://github.com/Tencent/rapidjson
   TITLE:=rapidjson JSON parser/generator for C++
 endef
 
-define Package/rapidjson/description
+define Package/$(PKG_NAME)/description
   A fast JSON parser/generator for C++ with both SAX/DOM style API
 endef
 
-$(eval $(call BuildPackage,rapidjson))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/subconverter/Makefile
+++ b/subconverter/Makefile
@@ -5,14 +5,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=subconverter
-PKG_BASE_VERSION:=0.7.0
+PKG_BASE_VERSION:=0.7.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/tindy2013/subconverter.git
-PKG_SOURCE_DATE:=2021-09-20
-PKG_SOURCE_VERSION:=fc641444aad07ebb620ac7c0c9501ffeddfa60d3
-PKG_MIRROR_HASH:=9b12004a3cd78c6803075a2f99431f7766a157993447eec5032d0d0d3d705979
+PKG_SOURCE_DATE:=2022-03-20
+PKG_SOURCE_VERSION:=406b0f20228b81d7ce06f2c4d49a5044fe015c23
+PKG_MIRROR_HASH:=48b23fdc0d4059b139100df0ff0b9be4e339e8e513388e2e057ccfc34d2e59f7
 
 PKG_VERSION:=$(PKG_BASE_VERSION)-$(PKG_SOURCE_DATE)-$(call version_abbrev,$(PKG_SOURCE_VERSION))
 
@@ -26,7 +26,7 @@ PKG_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-define Package/subconverter
+define Package/$(PKG_NAME)
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Utility to convert between various subscription format
@@ -34,7 +34,7 @@ define Package/subconverter
   DEPENDS:=+libpthread +libstdcpp +libevent2 +libyaml-cpp +libpcre2 +libcurl +zlib
 endef
 
-define Package/subconverter/description
+define Package/$(PKG_NAME)/description
   Utility to convert between various proxy subscription formats.
 endef
 
@@ -44,7 +44,7 @@ TARGET_LDFLAGS += -Wl,--gc-sections -flto
 
 CMAKE_OPTIONS += -DCMAKE_BUILD_TYPE=Release
 
-define Package/subconverter/install
+define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/subconverter $(1)/usr/bin/subconverter
 	$(INSTALL_DIR) $(1)/etc/subconverter
@@ -53,4 +53,4 @@ define Package/subconverter/install
 	$(INSTALL_BIN) ./files/subconverter.init $(1)/etc/init.d/subconverter
 endef
 
-$(eval $(call BuildPackage,subconverter))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/toml11/Makefile
+++ b/toml11/Makefile
@@ -21,16 +21,16 @@ CMAKE_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-define Package/toml11
+define Package/$(PKG_NAME)
   SECTION:=lib
   CATEGORY:=Libraries
   TITLE:=C++11 header-only toml parser/encoder
   URL:=https://github.com/ToruNiina/toml11
 endef
 
-define Package/toml11/description
+define Package/$(PKG_NAME)/description
   toml11 is a C++11 (or later) header-only toml parser/encoder
   depending only on C++ standard library.
 endef
 
-$(eval $(call BuildPackage,toml11))
+$(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
这个主repo很久没更新了，WYC-2020 的 fork做了一些修改（PKG_NAME），更新了依赖包版本，但没有pr。我把他的修改合并了，然后把subconverter 更新到了 2022-03-20 的 406b0f2